### PR TITLE
Add support for some Debian OS families.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class mcelog (
   }
 
   if $mcelog::params::service_manage {
-    if $::operatingsystemmajrelease == '7' {
+    if $::osfamily == 'Redhat' and $::operatingsystemmajrelease == '7' {
       file { 'mcelog.service':
         ensure  => 'file',
         path    => '/usr/lib/systemd/system/mcelog.service',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,7 @@ class mcelog::params {
     }
     'Debian': {
       case $::operatingsystemmajrelease {
-        '6', '7': {
+        '6', '7', '12.04', '14.04': {
           $config_file_path = '/etc/mcelog/mcelog.conf'
           $service_manage   = true
           $service_name     = 'mcelog'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class mcelog::params {
   $config_file_template = 'mcelog/mcelog.conf.erb'
 
   # MCE is only supported on x86_64
-  if $::architecture != 'x86_64' {
+  if ($::architecture != 'x86_64') and ($::architecture != 'amd64') {
     fail("Module ${module_name} is not supported on architecture: ${::architecture}")
   }
 
@@ -38,6 +38,18 @@ class mcelog::params {
               fail("Module ${module_name} is not supported on operatingsystemmajrelease: ${::operatingsystemmajrelease}")
             }
           }
+        }
+      }
+    }
+    'Debian': {
+      case $::operatingsystemmajrelease {
+        '6', '7': {
+          $config_file_path = '/etc/mcelog/mcelog.conf'
+          $service_manage   = true
+          $service_name     = 'mcelog'
+        }
+        default: {
+          fail("Module ${module_name} is not supported on operatingsystemmajrelease: ${::operatingsystemmajrelease}")
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -37,6 +37,20 @@
         "22"
       ]
     }
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+     {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04",
+        "14.04"
+      ]
+    },
   ],
   "dependencies": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
         "21",
         "22"
       ]
-    }
+    },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
@@ -44,13 +44,13 @@
         "7"
       ]
     },
-     {
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04",
         "14.04"
       ]
-    },
+    }
   ],
   "dependencies": [
     {

--- a/spec/classes/mcelog_spec.rb
+++ b/spec/classes/mcelog_spec.rb
@@ -192,6 +192,49 @@ describe 'mcelog', :type => :class do
     end # Fedora
   end # osfamily RedHat
 
+###
+  context 'osfamily Debian' do
+    let(:facts) {{
+      :architecture => 'amd64',
+      :osfamily     => 'Debian',
+    }}
+
+    context 'Debian6' do
+      before { facts[:operatingsystemmajrelease] = '6' }
+
+      it { should contain_package('mcelog').with_ensure('present') }
+      it do
+        should contain_file('mcelog.conf').with({
+          :ensure  => 'file',
+          :path    => '/etc/mcelog/mcelog.conf',
+          :owner   => 'root',
+          :group   => 'root',
+          :mode    => '0644',
+          :content => /^daemon = yes$/,
+        })
+      end
+      it { should contain_service('mcelog') }
+    end # Debian6
+
+    context 'Debian6' do
+      before { facts[:operatingsystemmajrelease] = '7' }
+
+      it { should contain_package('mcelog').with_ensure('present') }
+      it do
+        should contain_file('mcelog.conf').with({
+          :ensure  => 'file',
+          :path    => '/etc/mcelog/mcelog.conf',
+          :owner   => 'root',
+          :group   => 'root',
+          :mode    => '0644',
+          :content => /^daemon = yes$/,
+        })
+      end
+      it { should contain_service('mcelog') }
+    end # Debian7
+  end # osfamily Debian
+
+
   context 'unsupported architecture' do
     let :facts do
       {


### PR DESCRIPTION
This should add support for Debian 6, 7 and Ubuntu 12.04 and 14.04. 

I updated the test and tested it on Debian 6, 7 and Ubuntu 12.04.  14.04 looks the same, but I did actually run it on a 14.04 machine.

Tests have been updated, though they could probably be expanded a little more for the new OS's.  All are passing locally for me.