### PR TITLE
Adding Debian 8 support.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,7 @@ class mcelog::params {
     }
     'Debian': {
       case $::operatingsystemmajrelease {
-        '6', '7', '12.04', '14.04': {
+        '6', '7', '8', '12.04', '14.04': {
           $config_file_path = '/etc/mcelog/mcelog.conf'
           $service_manage   = true
           $service_name     = 'mcelog'


### PR DESCRIPTION
We're testing Proxmox 4.x, which is based on Debian 8.2.  Everything that matters for this seems the same as 7.
