### PR TITLE
Add service management params

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,3 +2,5 @@
 mcelog::package_name: mcelog
 mcelog::config_file_path: /etc/mcelog/mcelog.conf
 mcelog::service_name: mcelog
+mcelog::service_ensure: running
+mcelog::service_enable: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,10 @@
 #   The path of mcelog configuration file.
 # @param service_name
 #   The name of the service.
+# @param service_ensure
+#   The expected state of the service
+# @param service_enable
+#   Should the service start on boot?
 # @param config_file_content
 #   Literal string to write to config_file_path.
 #
@@ -14,6 +18,8 @@ class mcelog (
   String $package_name,
   Stdlib::Absolutepath $config_file_path,
   String $service_name,
+  Stdlib::Ensure::Service $service_ensure,
+  Boolean $service_enable,
   Optional[String] $config_file_content = undef,
 ) {
   ensure_packages($package_name)
@@ -32,8 +38,8 @@ class mcelog (
   }
 
   service { 'mcelog':
-    ensure  => running,
-    enable  => true,
+    ensure  => $service_ensure,
+    enable  => $service_enable,
     name    => $service_name,
     require => Package[$package_name],
   }

--- a/spec/classes/mcelog_spec.rb
+++ b/spec/classes/mcelog_spec.rb
@@ -20,6 +20,26 @@ describe 'mcelog', type: :class do
         end
       end
 
+      context 'with service disabled' do
+        let(:params) do
+          {
+            service_ensure: 'stopped',
+            service_enable: false,
+          }
+        end
+
+        it { is_expected.to contain_package('mcelog') }
+        it { is_expected.not_to contain_file('mcelog.conf') }
+
+        it do
+          is_expected.to contain_service('mcelog').with(
+            ensure: 'stopped',
+            enable: false,
+            name: 'mcelog',
+          ).that_requires('Package[mcelog]')
+        end
+      end
+
       context 'with config_file_content param' do
         let(:params) do
           {


### PR DESCRIPTION
There are a few ways to check if mcelog is supported by the hardware.  I may have to do some research before writing up something to make this smarter.

For now, on my site, I can just use these params to override hosts where it doesn't work.